### PR TITLE
Server gracefully shutdown

### DIFF
--- a/api/handler/url_handler.go
+++ b/api/handler/url_handler.go
@@ -27,7 +27,6 @@ func URLHandler(response http.ResponseWriter, request *http.Request) {
 
 	if request.Method != http.MethodPost {
 		http.Error(response, "Only POST method allowed", http.StatusMethodNotAllowed)
-		fmt.Println(request)
 		return
 	}
 

--- a/api/middleware/url_security_check.go
+++ b/api/middleware/url_security_check.go
@@ -8,7 +8,7 @@ import (
 
 /*
  *
- * I don't think this needs any kind of explanation
+ * Checks whether the URL isn't about local network IP
  *
  */
 func IsUrlSafe(u *url.URL) bool {

--- a/api/middleware/url_type_check.go
+++ b/api/middleware/url_type_check.go
@@ -55,18 +55,15 @@ func IsAboutVideo(urlString string) (bool, error) {
 		return false, err
 	}
 
-	/* First check */
 	if isVideoURL(parsedURL) {
 		return true, nil
 	}
 
-	/* Second check */
 	if contentIsVideo, err := isVideoContent(urlString); err != nil {
 		return false, err
 	} else if contentIsVideo {
 		return true, nil
 	}
 
-	/* Third check */
 	return isYoutubeLink(urlString), nil
 }

--- a/cmd/yt-go/main.go
+++ b/cmd/yt-go/main.go
@@ -21,8 +21,10 @@ func main() {
 	var undoButton = widget.NewButton("Undo them", func() { a.Preferences().SetBool("CONFIGURED", false) })
 
 	/* Initializes a Vertival Layout Container */
-	var mainWindowContent *fyne.Container = container.NewVBox(
-		undoButton,
+	var mainWindowContent *fyne.Container = container.NewPadded(
+		container.NewVBox(
+			undoButton,
+		),
 	)
 
 	/* Applies content to the window and resizes it */
@@ -71,5 +73,8 @@ func main() {
 
 	go func() { server.StartServer() }()
 	a.Run()
-	server.StopServer()
+
+	if err := server.StopServer(); err == nil {
+		fmt.Println("Server shutdown gracefully")
+	}
 }

--- a/cmd/yt-go/main.go
+++ b/cmd/yt-go/main.go
@@ -74,7 +74,7 @@ func main() {
 	go func() { server.StartServer() }()
 	a.Run()
 
-	if err := server.StopServer(); err == nil {
-		fmt.Println("Server shutdown gracefully")
+	if server.StopServer() == nil {
+		fmt.Println("Server shutdown gracefully. App closed")
 	}
 }

--- a/cmd/yt-go/main.go
+++ b/cmd/yt-go/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	preferences "yt-go/internal/preferences"
-	YtServer "yt-go/internal/server"
+	"yt-go/internal/preferences"
+	"yt-go/internal/server"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
@@ -53,8 +53,10 @@ func main() {
 	}
 
 	/*
-	* Minimizes the app when closed
-	* System Tray depending on current OS
+	 *
+	 * Minimizes the app when closed
+	 * System Tray depending on current OS
+	 *
 	 */
 	if desk, ok := a.(desktop.App); ok {
 		m := fyne.NewMenu("Yt-go",
@@ -67,6 +69,7 @@ func main() {
 		w.Hide()
 	})
 
-	go func() { YtServer.StartServer() }()
+	go func() { server.StartServer() }()
 	a.Run()
+	server.StopServer()
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,20 +1,67 @@
 package server
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"time"
+
 	"yt-go/api/handler"
 )
 
-func StartServer() {
-	http.HandleFunc("/_yt_", handler.URLHandler)
+var Srv *http.Server
 
-	fmt.Println("Listening on http://localhost:43214")
+func setEndpointHandlers(mux *http.ServeMux) {
+	mux.HandleFunc("GET /", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Hello, World!"))
+	})
+	mux.HandleFunc("POST /_yt_", handler.URLHandler)
+}
 
-	/* Returns Fatal error if server is closed unexpectedly */
-	if err := http.ListenAndServe(":43214", nil); !errors.Is(err, http.ErrServerClosed) {
-		log.Fatalf("ListenAndServer() : %v", err)
+func StopServer() error {
+	if Srv == nil {
+		fmt.Printf("HTTP server Shutdown error. Server not found")
+		return http.ErrServerClosed
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var err = Srv.Shutdown(ctx)
+	fmt.Println("Server shutdown gracefully")
+	return err
+}
+
+func StartServer() {
+	var mux *http.ServeMux = http.NewServeMux()
+	setEndpointHandlers(mux)
+
+	Srv = &http.Server{
+		Addr:    ":43214",
+		Handler: mux,
+	}
+
+	idleConnectionsClosed := make(chan struct{})
+	go func() {
+		sigint := make(chan os.Signal, 1)
+		signal.Notify(sigint, os.Interrupt)
+		<-sigint
+
+		if err := StopServer(); err != nil {
+			fmt.Printf("HTTP server Shutdown error: %v", err)
+		}
+		close(idleConnectionsClosed)
+	}()
+
+	fmt.Println("Server listening on http://localhost:43214")
+	if err := Srv.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {
+		log.Fatalf("HTTP server ListenAndServe error: %v", err)
+	}
+
+	<-idleConnectionsClosed
+	fmt.Println("Server shutdown gracefully")
 }

--- a/internal/types/url_data.go
+++ b/internal/types/url_data.go
@@ -1,7 +1,9 @@
 package types
 
 /*
-* Data structure of the JSON coming from web client
+ *
+ * Data structure of the JSON coming from web client
+ *
  */
 type URLData struct {
 	URL string `json:"url"`


### PR DESCRIPTION
Make the server shutdown when app is closed or when `SIGINT` (`Ctrl+c`) is typed, without overlapping on itself